### PR TITLE
Update Toolbar Icon Color for Light Theme

### DIFF
--- a/Thingies Light.json
+++ b/Thingies Light.json
@@ -13,7 +13,7 @@
     "tintColor2": "#73B3C0",
     "textColor": "#121417",
     "toolbarBackgroundColor": "#EBEBE4",
-    "toolbarIconColor": "#E0E2E8",
+    "toolbarIconColor": "#ABAFB4",
     "menuItemColor": "#c5c5c0",
     "timeBlockColor": "#929292",
     "shouldOverwriteFont": true


### PR DESCRIPTION
Changed the toolbar icon color to provide more contrast when viewed on an iPhone (and likely iPad)